### PR TITLE
Add `with-throttling` macro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,153 @@
+version: 2.1
+
+########################################################################################################################
+#                                                      EXECUTORS                                                       #
+########################################################################################################################
+
+executors:
+  default:
+    working_directory: /home/circleci/metabase/throttle/
+    docker:
+      - image: circleci/clojure:lein-2.8.1
+
+  java-11:
+    working_directory: /home/circleci/metabase/throttle/
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.8.1
+
+
+########################################################################################################################
+#                                                       COMMANDS                                                       #
+########################################################################################################################
+
+commands:
+
+  attach-workspace:
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+
+  restore-be-deps-cache:
+    steps:
+      - restore_cache:
+          keys:
+            - be-deps-{{ checksum "project.clj" }}
+            - be-deps-
+
+jobs:
+
+  checkout:
+    executor: default
+    steps:
+      - restore_cache:
+          keys:
+            - source-{{ .Branch }}-{{ .Revision }}
+            - source-{{ .Branch }}
+            - source-
+      - checkout
+      - save_cache:
+          key: source-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .git
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - metabase/throttle
+
+  be-deps:
+    executor: default
+    steps:
+      - attach-workspace
+      - restore-be-deps-cache
+      - run: lein deps
+      - save_cache:
+          key: be-deps-{{ checksum "project.clj" }}
+          paths:
+            - /home/circleci/.m2
+
+  lein:
+    parameters:
+      e:
+        type: executor
+        default: default
+      lein-command:
+        type: string
+    executor: << parameters.e >>
+    steps:
+      - attach-workspace
+      - restore-be-deps-cache
+      - run:
+          command: lein << parameters.lein-command >>
+          no_output_timeout: 5m
+
+  deploy:
+    executor: default
+    steps:
+      - attach-workspace
+      - run:
+          name: Deploy to clojars
+          command: lein deploy clojars
+
+
+########################################################################################################################
+#                                                      WORKFLOWS                                                       #
+########################################################################################################################
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - checkout
+
+      - be-deps:
+          requires:
+            - checkout
+
+      - lein:
+          name: be-tests
+          requires:
+            - be-deps
+          lein-command: test
+
+      - lein:
+          name: be-tests-java-11
+          requires:
+            - be-deps
+          e: java-11
+          lein-command: test
+
+      - lein:
+          name: be-linter-eastwood
+          requires:
+            - be-deps
+          lein-command: eastwood
+
+      - lein:
+          name: be-linter-docstring-checker
+          requires:
+            - be-deps
+          lein-command: docstring-checker
+
+      - lein:
+          name: be-linter-namespace-decls
+          requires:
+            - be-deps
+          lein-command: check-namespace-decls
+
+      - lein:
+          name: be-linter-bikeshed
+          requires:
+            - be-deps
+          lein-command: bikeshed
+
+      - deploy:
+          requires:
+            - be-linter-bikeshed
+            - be-linter-docstring-checker
+            - be-linter-eastwood
+            - be-linter-namespace-decls
+            - be-tests
+            - be-tests-java-11
+          filters:
+            branches:
+              only: master

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ Then call `check` at the appropriate point in your code with some value to apply
   ...)
 ```
 
+If you only want to throttle failures of some operation, like login attempts, you can use `with-throttling`.
+
+```clojure
+(defn my-login-fn [username password]
+  (throttle/with-throttling [login-throttler username]
+    (login username password)))
+```
+
+In the above case throttling will only kick in after `login` threw an exception `attempts-threshold` times.
+
+`with-throttling` accepts multiple throttler-key pairs.
+
 ### Configuration
 
 The following are options that can be passed to `make-throttler`:

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,0 @@
-test:
-  override:
-    - case $CIRCLE_NODE_INDEX in 0) lein eastwood ;; 1) lein test ;; 2) lein bikeshed ;; esac:
-        parallel: true

--- a/project.clj
+++ b/project.clj
@@ -1,17 +1,72 @@
 (defproject metabase/throttle "1.0.1"
   :description "Simple tools for throttling API endpoints and other code."
   :url "https://github.com/metabase/throttle"
+  :min-lein-version "2.5.0"
+
   :license {:name "Lesser GPL"
             :url "https://www.gnu.org/licenses/lgpl.txt"}
-  :min-lein-version "2.5.0"
-  :dependencies [[org.clojure/math.numeric-tower "0.0.4"
-                  :exclusions [org.clojure/clojure]]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [expectations "2.1.4"]]
-                   :plugins [[lein-expectations "0.0.8"]
-                             [jonase/eastwood "0.2.3"]
-                             [lein-bikeshed "0.3.0"]]
-                   :eastwood {:add-linters [:unused-private-vars]}
-                   :aliases {"bikeshed" ["bikeshed" "--max-line-length" "160"]
-                             "test" ["expectations"]}}}
-  :deploy-repositories [["clojars" {:sign-releases false}]])
+
+  :aliases
+  {"test"                      ["with-profile" "+expectations" "expectations"]
+   "bikeshed"                  ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "120"]
+   "check-namespace-decls"     ["with-profile" "+check-namespace-decls" "check-namespace-decls"]
+   "eastwood"                  ["with-profile" "+eastwood" "eastwood"]
+   "check-reflection-warnings" ["with-profile" "+reflection-warnings" "check"]
+   "docstring-checker"         ["with-profile" "+docstring-checker" "docstring-checker"]
+   ;; `lein lint` will run all linters
+   "lint"                      ["do" ["eastwood"] ["bikeshed"] ["check-namespace-decls"] ["docstring-checker"]]}
+
+  :dependencies
+  [[org.clojure/math.numeric-tower "0.0.4" :exclusions [org.clojure/clojure]]]
+
+  :profiles
+  {:dev
+   {:dependencies
+    [[org.clojure/clojure "1.8.0"]
+     [expectations "2.1.4"]]
+
+    :injections
+    [(require 'expectations)
+     ((resolve 'expectations/disable-run-on-shutdown))]
+
+    :jvm-opts
+    ["-Xverify:none"]}
+
+   :expectations
+   {:plugins [[lein-expectations "0.0.8" :exclusions [expectations]]]}
+
+   :eastwood
+   {:plugins
+    [[jonase/eastwood "0.3.5" :exclusions [org.clojure/clojure]]]
+
+    :add-linters
+    [:unused-private-vars
+     :unused-namespaces
+     :unused-fn-args
+     :unused-locals]
+
+    :exclude-linters
+    [:deprecations]}
+
+   :docstring-checker
+   {:plugins
+    [[docstring-checker "1.0.3"]]
+
+    :docstring-checker
+    {:exclude [#"test"]}}
+
+   :bikeshed
+   {:plugins
+    [[lein-bikeshed "0.5.2"]]}
+
+   :check-namespace-decls
+   {:plugins               [[lein-check-namespace-decls "1.0.2"]]
+    :source-paths          ["test"]
+    :check-namespace-decls {:prefix-rewriting true}}}
+
+  :deploy-repositories
+  [["clojars"
+    {:url           "https://clojars.org/repo"
+     :username      :env/clojars_username
+     :password      :env/clojars_password
+     :sign-releases false}]])

--- a/src/throttle/core.clj
+++ b/src/throttle/core.clj
@@ -95,10 +95,10 @@
 
 (defmacro with-throttling {:style/indent 2}
   [throttler keyy & body]
-  "Do BODY if attempts for KEYY on THROTTLER has not been exceeded.
-  If BODY fails (throws an exception), an failed attempt is counted and the exception is re-thrown. If failed attempts
-  threshold was exceeded, an exception is thrown. Attempts made while the threshold is exceeded, are counted as failed
-  attempts."
+  "Do BODY if failed attempts for KEYY on THROTTLER has not been exceeded.
+  If BODY throws an exception, a failed attempt is counted and the exception is re-thrown. If the failed attempts
+  threshold is exceeded, an exception is thrown and BODY is not executed. Attempts made while the threshold is
+  exceeded are counted as additional failed attempts."
   `(do-with-throttling ~throttler ~keyy (fn [] ~@body)))
 
 ;;; # INTERNAL IMPLEMENTATION

--- a/src/throttle/core.clj
+++ b/src/throttle/core.clj
@@ -95,7 +95,10 @@
 
 (defmacro with-throttling {:style/indent 2}
   [throttler keyy & body]
-  "`check` the given KEYY on THROTTLER, in an implicit `do`."
+  "Do BODY if attempts for KEYY on THROTTLER has not been exceeded.
+  If BODY fails (throws an exception), an failed attempt is counted and the exception is re-thrown. If failed attempts
+  threshold was exceeded, an exception is thrown. Attempts made while the threshold is exceeded, are counted as failed
+  attempts."
   `(do-with-throttling ~throttler ~keyy (fn [] ~@body)))
 
 ;;; # INTERNAL IMPLEMENTATION

--- a/src/throttle/core.clj
+++ b/src/throttle/core.clj
@@ -101,8 +101,12 @@
   threshold is exceeded, an exception is thrown and `body` is not executed. Attempts made while the threshold is
   exceeded are counted as additional failed attempts."
   {:style/indent 2}
-  [throttler keyy & body]
-  `(do-with-throttling ~throttler ~keyy (fn [] ~@body)))
+  [[throttler key & more] & body]
+  (if (seq more)
+    `(with-throttling [~throttler ~key]
+       (with-throttling [~@more]
+         ~@body))
+    `(do-with-throttling ~throttler ~key (fn [] ~@body))))
 
 ;;; # INTERNAL IMPLEMENTATION
 

--- a/src/throttle/core.clj
+++ b/src/throttle/core.clj
@@ -12,16 +12,16 @@
                       ;; [Internal] List of attempt entries. These are pairs of [key timestamp (ms)],
                       ;; e.g. ["cam@metabase.com" 1438045261132]
                       ^Atom    attempts
-                      ;; Amount of time to keep an entry in ATTEMPTS before dropping it.
+                      ;; Amount of time to keep an entry in `attempts` before dropping it.
                       ^Integer attempt-ttl-ms
                       ;; Number of attempts allowed with a given key before throttling is applied.
                       ^Integer attempts-threshold
                       ;; Once throttling is in effect, initial delay before allowing another attempt. This grows
-                      ;; according to DELAY-EXPONENT.
+                      ;; according to `delay-exponent`.
                       ^Integer initial-delay-ms
-                      ;; For each subsequent failure past ATTEMPTS-THRESHOLD, increase the delay to
-                      ;; INITIAL-DELAY-MS * (num-attempts-over-theshold ^ DELAY-EXPONENT). e.g. if INITIAL-DELAY-MS is
-                      ;; 15 and DELAY-EXPONENT is 2, the first attempt past ATTEMPTS-THRESHOLD will require the user to
+                      ;; For each subsequent failure past `attempts-threshold`, increase the delay to `initial-delay-ms
+                      ;; * (num-attempts-over-theshold ^ delay-exponent)`. e.g. if `initial-delay-ms` is 15 and
+                      ;; `delay-exponent` is 2, the first attempt past `attempts-threshold` will require the user to
                       ;; wait 15 seconds (15 * 1^2), the next attempt after that 60 seconds (15 * 2^2), then 135, and so
                       ;; on.
                       ^Integer delay-exponent])
@@ -46,8 +46,8 @@
                                                     :exception-field-key exception-field-key})))
 
 (defn check
-  "Throttle an API call based on values of KEYY. Each call to this function will record KEYY to THROTTLER's internal
-  list; if the number of entires containing KEYY exceed THROTTLER's thresholds, throw an exception.
+  "Throttle an API call based on values of `keyy`. Each call to this function will record `keyy` to `throttler`'s
+  internal list; if the number of entires containing `keyy` exceed `throttler`'s thresholds, throw an exception.
 
      (defendpoint POST [:as {{:keys [email]} :body}]
        (throttle/check email-throttler email)
@@ -96,9 +96,9 @@
       (throw e))))
 
 (defmacro with-throttling
-  "Do BODY if failed attempts for KEYY on THROTTLER has not been exceeded.
-  If BODY throws an exception, a failed attempt is counted and the exception is re-thrown. If the failed attempts
-  threshold is exceeded, an exception is thrown and BODY is not executed. Attempts made while the threshold is
+  "Do `body` if failed attempts for `keyy` on `throttler` has not been exceeded.
+  If `body` throws an exception, a failed attempt is counted and the exception is re-thrown. If the failed attempts
+  threshold is exceeded, an exception is thrown and `body` is not executed. Attempts made while the threshold is
   exceeded are counted as additional failed attempts."
   {:style/indent 2}
   [throttler keyy & body]
@@ -107,7 +107,7 @@
 ;;; # INTERNAL IMPLEMENTATION
 
 (defn- remove-old-attempts
-  "Remove THROTTLER entires past the TTL."
+  "Remove `throttler` entires past the TTL."
   [^Throttler {:keys [attempts attempt-ttl-ms]}]
   (let [old-attempt-cutoff (- (System/currentTimeMillis) attempt-ttl-ms)
         non-old-attempt?   (fn [[_ timestamp]]
@@ -115,7 +115,7 @@
     (reset! attempts (take-while non-old-attempt? @attempts))))
 
 (defn- calculate-delay
-  "Calculate the delay in milliseconds, if any, that should be applied to a given THROTTLER / KEYY combination."
+  "Calculate the delay in milliseconds, if any, that should be applied to a given `throttler`/`keyy` combination."
   ([^Throttler throttler keyy]
    (calculate-delay throttler keyy (System/currentTimeMillis)))
 

--- a/test/throttle/core_test.clj
+++ b/test/throttle/core_test.clj
@@ -2,7 +2,11 @@
   (:require [expectations :refer :all]
             [throttle.core :as throttle]))
 
-(def ^:private test-throttler (throttle/make-throttler :test, :initial-delay-ms 5, :attempts-threshold 3, :delay-exponent 2, :attempt-ttl-ms 25))
+(def ^:private test-throttler (throttle/make-throttler :test,
+                                                       :initial-delay-ms 5,
+                                                       :attempts-threshold 3,
+                                                       :delay-exponent 2,
+                                                       :attempt-ttl-ms 25))
 
 ;;; # tests for calculate-delay
 (def calculate-delay @(resolve 'throttle.core/calculate-delay))

--- a/test/throttle/core_test.clj
+++ b/test/throttle/core_test.clj
@@ -2,122 +2,145 @@
   (:require [expectations :refer :all]
             [throttle.core :as throttle]))
 
-(def ^:private test-throttler (throttle/make-throttler :test,
-                                                       :initial-delay-ms 5,
-                                                       :attempts-threshold 3,
-                                                       :delay-exponent 2,
-                                                       :attempt-ttl-ms 25))
+(defn- make-test-throttler []
+  (throttle/make-throttler :test,
+                           :initial-delay-ms 5,
+                           :attempts-threshold 3,
+                           :delay-exponent 2,
+                           :attempt-ttl-ms 25))
 
 ;;; # tests for calculate-delay
 (def calculate-delay @(resolve 'throttle.core/calculate-delay))
 
 ;; no delay should be calculated for the 3rd attempt
-(expect nil
-  (do (reset! (:attempts test-throttler) '([:x 100], [:x 99]))
-      (calculate-delay test-throttler :x 101)))
+(expect
+  nil
+  (let [test-throttler (make-test-throttler)]
+    (reset! (:attempts test-throttler) '([:x 100], [:x 99]))
+    (calculate-delay test-throttler :x 101)))
 
 ;; 4 ms delay on 4th attempt 1ms after the last
-(expect 4
-  (do (reset! (:attempts test-throttler) '([:x 100], [:x 99], [:x 98]))
-      (calculate-delay test-throttler :x 101)))
+(expect
+  4
+  (let [test-throttler (make-test-throttler)]
+    (reset! (:attempts test-throttler) '([:x 100], [:x 99], [:x 98]))
+    (calculate-delay test-throttler :x 101)))
 
 ;; 5 ms after last attempt, they should be allowed to try again
-(expect nil
-  (do (reset! (:attempts test-throttler) '([:x 100], [:x 99], [:x 98]))
-      (calculate-delay test-throttler :x 105)))
+(expect
+  nil
+  (let [test-throttler (make-test-throttler)]
+    (reset! (:attempts test-throttler) '([:x 100], [:x 99], [:x 98]))
+    (calculate-delay test-throttler :x 105)))
 
 ;; However if this was instead the 5th attempt delay should grow exponentially (5 * 2^2 = 20), - 2ms = 18ms
-(expect 18
-  (do (reset! (:attempts test-throttler) '([:x 100], [:x 99], [:x 98], [:x 97]))
-      (calculate-delay test-throttler :x 102)))
+(expect
+  18
+  (let [test-throttler (make-test-throttler)]
+    (reset! (:attempts test-throttler) '([:x 100], [:x 99], [:x 98], [:x 97]))
+    (calculate-delay test-throttler :x 102)))
 
 ;; Should be allowed after 18 more secs
-(expect nil
-  (do (reset! (:attempts test-throttler) '([:x 100], [:x 99], [:x 98], [:x 97]))
-      (calculate-delay test-throttler :x 120)))
+(expect
+  nil
+  (let [test-throttler (make-test-throttler)]
+    (reset! (:attempts test-throttler) '([:x 100], [:x 99], [:x 98], [:x 97]))
+    (calculate-delay test-throttler :x 120)))
 
 ;; Check that delay keeps growing according to delay-exponent (5 * 3^2 = 5 * 9 = 45)
-(expect 45
-  (do (reset! (:attempts test-throttler) '([:x 108], [:x 100], [:x 99], [:x 98], [:x 97]))
-      (calculate-delay test-throttler :x 108)))
+(expect
+  45
+  (let [test-throttler (make-test-throttler)]
+    (reset! (:attempts test-throttler) '([:x 108], [:x 100], [:x 99], [:x 98], [:x 97]))
+    (calculate-delay test-throttler :x 108)))
 
 
 ;;; # tests for check
 
-(defn- attempt
-  ([n]
-   (attempt n (gensym)))
-  ([n k]
-   (let [attempt-once (fn []
-                      (try
-                        (Thread/sleep 1)
-                        (throttle/check test-throttler k)
-                        :success
-                        (catch Throwable e
-                          (:test (:errors (ex-data e))))))]
-     (vec (repeatedly n attempt-once)))))
+(let [test-throttler (make-test-throttler)]
+  (defn- attempt
+    ([n]
+     (attempt n (gensym)))
+    ([n k]
+     (let [attempt-once (fn []
+                          (try
+                            (Thread/sleep 1)
+                            (throttle/check test-throttler k)
+                            :success
+                            (catch Throwable e
+                              (:test (:errors (ex-data e))))))]
+       (vec (repeatedly n attempt-once)))))
 
-;; a couple of quick "attempts" shouldn't trigger the throttler
-(expect [:success :success]
-  (attempt 2))
+  ;; a couple of quick "attempts" shouldn't trigger the throttler
+  (expect
+    [:success :success]
+    (attempt 2))
 
-;; nor should 3
-(expect [:success :success :success]
-  (attempt 3))
+  ;; nor should 3
+  (expect
+    [:success :success :success]
+    (attempt 3))
 
-;; 4 in quick succession should trigger it
-(expect [:success :success :success "Too many attempts! You must wait 0 seconds before trying again."] ; rounded down
-  (attempt 4))
+  ;; 4 in quick succession should trigger it
+  (expect
+    [:success :success :success "Too many attempts! You must wait 0 seconds before trying again."] ; rounded down
+    (attempt 4))
 
-;; Check that throttling correctly lets you try again after certain delay
-(expect [[:success :success :success "Too many attempts! You must wait 0 seconds before trying again."]
-         [:success]]
-  [(attempt 4 :a)
-   (do
-     (Thread/sleep 6)
-     (attempt 1 :a))])
+  ;; Check that throttling correctly lets you try again after certain delay
+  (expect
+    [[:success :success :success "Too many attempts! You must wait 0 seconds before trying again."]
+     [:success]]
+    [(attempt 4 :a)
+     (do
+       (Thread/sleep 6)
+       (attempt 1 :a))])
 
-;; Next attempt should be throttled, however
-(expect [:success "Too many attempts! You must wait 0 seconds before trying again."]
-  (do
-    (attempt 4 :b)
-    (Thread/sleep 6)
-    (attempt 2 :b)))
+  ;; Next attempt should be throttled, however
+  (expect
+    [:success "Too many attempts! You must wait 0 seconds before trying again."]
+    (do
+      (attempt 4 :b)
+      (Thread/sleep 6)
+      (attempt 2 :b)))
 
-;; Sleeping 5+ ms after that shouldn't work due to exponential growth
-(expect ["Too many attempts! You must wait 0 seconds before trying again."]
-  (do
-    (attempt 4 :c)
-    (Thread/sleep 6)
-    (attempt 2 :c)
-    (Thread/sleep 6)
-    (attempt 1 :c)))
+  ;; Sleeping 5+ ms after that shouldn't work due to exponential growth
+  (expect
+    ["Too many attempts! You must wait 0 seconds before trying again."]
+    (do
+      (attempt 4 :c)
+      (Thread/sleep 6)
+      (attempt 2 :c)
+      (Thread/sleep 6)
+      (attempt 1 :c)))
 
-;; Sleeping 20+ ms however should work
-(expect [:success]
-  (do
-    (attempt 4 :d)
-    (Thread/sleep 6)
-    (attempt 2 :d)
-    (Thread/sleep 21)
-    (attempt 1 :d)))
+  ;; Sleeping 20+ ms however should work
+  (expect
+    [:success]
+    (do
+      (attempt 4 :d)
+      (Thread/sleep 6)
+      (attempt 2 :d)
+      (Thread/sleep 21)
+      (attempt 1 :d)))
 
-;; Check that the interal list for the throttler doesn't keep growing after throttling starts
-(expect [0 3]
-  [(do (reset! (:attempts test-throttler) '()) ; reset it to 0
-       (count @(:attempts test-throttler)))
-   (do (attempt 5)
-       (count @(:attempts test-throttler)))])
+  ;; Check that the interal list for the throttler doesn't keep growing after throttling starts
+  (expect
+    [0 3]
+    [(do (reset! (:attempts test-throttler) '()) ; reset it to 0
+         (count @(:attempts test-throttler)))
+     (do (attempt 5)
+         (count @(:attempts test-throttler)))])
 
-;; Check that attempts clear after the TTL
-(expect [0 3 1]
-  [(do (reset! (:attempts test-throttler) '()) ; reset it to 0
-       (count @(:attempts test-throttler)))
-   (do (attempt 3)
-       (count @(:attempts test-throttler)))
-   (do (Thread/sleep 25)
-       (attempt 1)
-       (count @(:attempts test-throttler)))])
+  ;; Check that attempts clear after the TTL
+  (expect
+    [0 3 1]
+    [(do (reset! (:attempts test-throttler) '()) ; reset it to 0
+         (count @(:attempts test-throttler)))
+     (do (attempt 3)
+         (count @(:attempts test-throttler)))
+     (do (Thread/sleep 25)
+         (attempt 1)
+         (count @(:attempts test-throttler)))]))
 
 
 ;;; # tests for with-throttling
@@ -125,8 +148,7 @@
 ;; Check that no attempts are recorded for empty throttled body
 (expect
   0
-  (do
-    (reset! (:attempts test-throttler) '())
+  (let [test-throttler (make-test-throttler)]
     (throttle/with-throttling [test-throttler :test])
     (count @(:attempts test-throttler))))
 
@@ -140,8 +162,9 @@
       (login-failed))
     (catch Throwable _)))
 
-(let [max-allowed-failures (dec (:attempts-threshold test-throttler))]
-  ;; Failed throttled attempts are recorded, and non-failing attempt succeeds while under threshold
+;; Failed throttled attempts are recorded, and non-failing attempt succeeds while under threshold
+(let [test-throttler       (make-test-throttler)
+      max-allowed-failures (dec (:attempts-threshold test-throttler))]
   (expect
     max-allowed-failures
     (do
@@ -156,11 +179,10 @@
       (count @(:attempts test-throttler)))))
 
 ;; Check that first throttled attempt fails, after threshold has been reached
-(expect
-  (:attempts-threshold test-throttler)
-  (let []
+(let [test-throttler (make-test-throttler)]
+  (expect
+    (:attempts-threshold test-throttler)
     (do
-      (reset! (:attempts test-throttler) '())
       (dotimes [_ (:attempts-threshold test-throttler)]
         (try
           (throttle/with-throttling [test-throttler :test]
@@ -169,23 +191,23 @@
       (count @(:attempts test-throttler)))))
 
 ;; Check that throttled attempt is allowed after old attempt expired
-(expect
-  (inc (:attempts-threshold test-throttler))
-  (do
-    (reset! (:attempts test-throttler) '())
-    (throttled-login-failure test-throttler) ; First failed attempt.
-    (Thread/sleep 15)
-    ;; Use up all remaining allowed attempts:
-    (dotimes [_ (dec (:attempts-threshold test-throttler))]
-      (throttled-login-failure test-throttler))
-    ;; At this point were at `threshold` attempts already.
-    (throttled-login-failure test-throttler)
-    ;; Now we're at `threshold`+1 attempts.
-    (Thread/sleep 15)
-    ;; The first attempt (before the `dotimes`) should have expired by now, so we're back to `threshold` attempts.
-    (throttled-login-failure test-throttler)
-    ;; Added another attempt to allow `remove-old-attempts` to be triggered. Back to `threshold`+ 1 attempts.
-    (count @(:attempts test-throttler))))
+(let [test-throttler (make-test-throttler)]
+  (expect
+    (inc (:attempts-threshold test-throttler))
+    (do
+      (throttled-login-failure test-throttler) ; First failed attempt.
+      (Thread/sleep 15)
+      ;; Use up all remaining allowed attempts:
+      (dotimes [_ (dec (:attempts-threshold test-throttler))]
+        (throttled-login-failure test-throttler))
+      ;; At this point were at `threshold` attempts already.
+      (throttled-login-failure test-throttler)
+      ;; Now we're at `threshold`+1 attempts.
+      (Thread/sleep 15)
+      ;; The first attempt (before the `dotimes`) should have expired by now, so we're back to `threshold` attempts.
+      (throttled-login-failure test-throttler)
+      ;; Added another attempt to allow `remove-old-attempts` to be triggered. Back to `threshold`+ 1 attempts.
+      (count @(:attempts test-throttler)))))
 
 ;; Test with multiple throttlers
 (expect

--- a/test/throttle/core_test.clj
+++ b/test/throttle/core_test.clj
@@ -170,10 +170,10 @@
       (Thread/sleep 15)
       (dotimes [_ (dec threshold)] ; Use up all remaining allowed attempts.
         (throttled-fail))
-      ; At this point were at `threshold` attempts already.
+      ;; At this point were at `threshold` attempts already.
       (throttled-fail)
-      ; Now we're at `threshold`+1 attempts.
+      ;; Now we're at `threshold`+1 attempts.
       (Thread/sleep 15)
-      ; The first attempt (before the `dotimes`) should have expired by now, so we're back to `threshold` attempts.
+      ;; The first attempt (before the `dotimes`) should have expired by now, so we're back to `threshold` attempts.
       (throttled-fail) ; Add another attempt to allow `remove-old-attempts` to be triggered. Back to `threshold`+ 1.
       (count @(:attempts test-throttler)))))


### PR DESCRIPTION
This approach separates the checking of the attempts threshold from the recording of a new attempt. Only failed attempts are recorded.